### PR TITLE
opengrok.md proofread

### DIFF
--- a/doc/code_search/how-to/opengrok.md
+++ b/doc/code_search/how-to/opengrok.md
@@ -13,39 +13,39 @@
 
 ### Wildcards vs. regular expressions
 
-Oracle OpenGrok provides wildcard support for searches. For example, to find all strings beginning with `foo`, you can use the wildcard search `foo*`. Similarly, OpenGrok provides the `?` operator for single character wildcards.
+Oracle OpenGrok provides wildcard support for searches. For example, to find all strings beginning with `foo`, you can use the wildcard search `foo*`. Similarly, OpenGrok provides the `?` operator for single-character wildcards.
 
-Sourcegraph, [provides full regular expression search](../reference/queries.md#regexp-search), with support for the [RE2 syntax](https://golang.org/s/re2syntax). The same search above would take the form `foo.*` (or in this case, just `foo`, since Sourcegraph automatically supports partial matches). Much more powerful regexp expressions are available.
+Sourcegraph [provides full regular expression search](../reference/queries.md#regexp-search) with support for the [RE2 syntax](https://golang.org/s/re2syntax). The same search above would take the form `foo.*` (or in this case, just `foo`, since Sourcegraph automatically supports partial matches). Much more powerful regexp expressions are available.
 
 (Note that Sourcegraph also provides a [literal search mode](../reference/queries.md#Literal-search-default) by default, in which there's no need to escape special characters. This simplifies searches such as `foo(`, which would result in an error in regexp mode.)
 
 ### Selecting repositories and branches
 
-Oracle OpenGrok provides a multi-select dropdown box to allow users to select which repositories to include in a search. This scope is stored across sessions, until the user changes it.
+Oracle OpenGrok provides a multi-select dropdown box to allow users to select which repositories to include in a search. This scope is stored across sessions until the user changes it.
 
 Sourcegraph provides a search keyword (`repo:`) that supports regexp and partial matches for selecting repositories. As examples:
 
 - To search for the string "pattern" in all repositories in the github.com/org org, search for `pattern repo:github.com/org`.
 - To search in a distinct list of repositories, you can use a `|` character as a regexp OR operator: `pattern repo:github.com/org/repository1|github.com/org/repository2`.
-  - Note this query could be simplified further using more advanced regexp matching if the two repos share part of their names, such as: `pattern repo:github.com/org/repository(1|2)`.
+  - Note that this query could be simplified further using more advanced regexp matching if the two repos share part of their names, such as: `pattern repo:github.com/org/repository(1|2)`.
 
-Sourcegraph also allows site admins to create pre-defined repository groupings, using [version contexts](../explanations/features.md#version-contexts-experimental).
+Sourcegraph also allows site admins to create pre-defined repository groupings using [version contexts](../explanations/features.md#version-contexts-experimental).
 
 ### Searching in non-master (unindexed) branches, tags, and commits
 
 Oracle OpenGrok can only search in the version of code that is stored on disk. To search across multiple revisions or branches, an OpenGrok administrator must explicitly add each of those copies of the code to OpenGrok.
 
-Sourcegraph allows users to search on any Git revision, even if it is not indexed. Users can append `@<git rev>` to the end of any `repo:` keyword to specify which version to search. For example, to search on `feature-branch`, use `pattern repo:github.com/org/repo@feature-branch`, and to search on a commit `abc123`, use `pattern repo:github.com/org/repo@abc123`.
+Sourcegraph allows users to search any Git revision, even if it is not indexed. Users can append `@<git rev>` to the end of any `repo:` keyword to specify which version to search. For example, to search on `feature-branch`, use `pattern repo:github.com/org/repo@feature-branch`, and to search on a commit `abc123`, use `pattern repo:github.com/org/repo@abc123`.
 
-Sourcegraph also provides the ability to search on multiple Git revisions in a single repository at once, using `:` characters to separate revision names in the `repo:` field. For example, search both `feature-branch` and `abc123` in a single query using `pattern repo:github.com/org/repo@feature-branch:abc123`.
+Sourcegraph also provides the ability to search on multiple Git revisions in a single repository at once using `:` characters to separate revision names in the `repo:` field. For example, search both `feature-branch` and `abc123` in a single query using `pattern repo:github.com/org/repo@feature-branch:abc123`.
 
 ### Special characters
 
-Oracle OpenGrok doesn't index most single-character strings (such as for special characters like `{`, `}`, `[`, `]`, `+`, `-`, and more), and non-alpha-numeric characters generally.
+Oracle OpenGrok doesn't index most single-character strings (such as special characters like `{`, `}`, `[`, `]`, `+`, `-`, and more) and non-alphanumeric characters generally.
 
-Sourcegraph indexes all characters, and can search for strings of any length. Using the default [literal search mode](../reference/queries.md#Literal-search-default), any search (including those with special characters like `foo.bar`, `try {`, `i++`, `i-=1`, `foo->bar`, and more), will all be searchable without special handling. Using [regexp mode](../reference/queries.md#regexp-search) would require escaping special charactes.
+Sourcegraph indexes all characters and can search for strings of any length. Using the default [literal search mode](../reference/queries.md#Literal-search-default), any search (including those with special characters like `foo.bar`, `try {`, `i++`, `i-=1`, `foo->bar`, and more) will be searchable without special handling. Using [regexp mode](../reference/queries.md#regexp-search) would require escaping special characters.
 
-The only exceptions are colon characters, which are by default used for specifying a [search keyword](#search-keywords) on Sourcegraph. Any search containing colons can be done using the `content:` keyword (for example, `content:"foo::bar"`) to explicitly mark it as the search string.
+The only exception to this convention is the colon, which is by default used for specifying a [search keyword](#search-keywords) on Sourcegraph. Any search containing colons can be done using the `content:` keyword (for example, `content:"foo::bar"`) to explicitly mark it as the search string.
 
 ### Boolean operators
 


### PR DESCRIPTION
Line 16: Added hyphen to "single-character wildcards".
Line 18: Removed commas around "provides full regular expression search".
Line 24: Removed comma after "sessions".
Line 30: Added "that" in "Note that this query".
Line 32: Removed comma after "groupings".
Line 38: Removed "on" from "allows users to search on any Git revision".
Line 40: Removed comma after "at once".
Line 44: Removed "for" from "such as for special characters". Removed comma after closing parenthesis. Changed "non-alpha-numeric" to "non-alphanumeric".
Line 46: Removed comma after "characters". Removed comma after closing parenthesis. Removed "all" from "will all be searchable". Corrected spelling of "characters".
Line 48: Rewrote the sentence in the singular. Added "to this convention" to make the sentence more specific.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
